### PR TITLE
Don't ceate/push git tag in dry run modified

### DIFF
--- a/script/publish.sh
+++ b/script/publish.sh
@@ -78,6 +78,7 @@ cargo package
 
 if [[ "${MODE}" == "--dry-run" ]]; then
     CMD="cargo publish --dry-run --token ${TOKEN}"
+    eval $CMD
 else    
     git tag $VERSION
     CMD="cargo publish --token ${TOKEN}"


### PR DESCRIPTION
Actually it doesn't make sense to publish tags when running in dry-run mode. Changing this script slightly