### PR TITLE
Remove StatsdBuilder::install and add docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
-## [v0.18.0](https://github.com/github/metrics-exporter-statsd/tree/0.18.0) - 2022-06-03
+## [v0.2.0](https://github.com/github/metrics-exporter-statsd/tree/0.2.0) - 2022-06-03
 
 * Removed the support for installing global recorder via `StatsdBuilder`, since that can cause metrics to stop emitting when the importing app may
   link a different version of `metrics` than this library depends on.
 * The calling app must now invoke `metrics::set_boxed_recorder` after building the recorder via `StatsdBuilder`
 * Updated documentation to reflect that. 
-* The version of this crate now matches the version of `metrics` crate it uses.
 
 ## [v0.1.0](https://github.com/github/metrics-exporter-statsd/tree/0.1.0) - 2022-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [v0.18.0](https://github.com/github/metrics-exporter-statsd/tree/0.18.0) - 2022-06-03
+
+* Removed the support for installing global recorder via `StatsdBuilder`, since that can cause metrics to stop emitting when the importing app may
+  link a different version of `metrics` than this library depends on.
+* The calling app must now invoke `metrics::set_boxed_recorder` after building the recorder via `StatsdBuilder`
+* Updated documentation to reflect that. 
+* The version of this crate now matches the version of `metrics` crate it uses.
+
 ## [v0.1.0](https://github.com/github/metrics-exporter-statsd/tree/0.1.0) - 2022-06-02
 
 * Initial release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-statsd"
-version = "0.18.0"
+version = "0.2.0"
 dependencies = [
  "cadence",
  "metrics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-statsd"
-version = "0.1.0"
+version = "0.18.0"
 dependencies = [
  "cadence",
  "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics-exporter-statsd"
-version = "0.18.0"
+version = "0.2.0"
 authors = ["Manish Bellani <mbellani@github.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics-exporter-statsd"
-version = "0.1.0"
+version = "0.18.0"
 authors = ["Manish Bellani <mbellani@github.com>"]
 edition = "2021"
 license = "MIT"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -124,6 +124,22 @@ impl StatsdBuilder {
         self
     }
 
+    /// This method is responsible building the StatsdRecorder. It configures the underlying metrics sink for 
+    /// the [`StatsdClient`] with the values provided e.g. `queue_size`, `buffer_size` etc.
+    ///
+    /// All the metrics emitted from the recorder are prefixed with the prefix that's provided here.
+    ///
+    /// # Examples
+    /// ```
+    /// use metrics_exporter_statsd::StatsdBuilder;
+    /// let recorder = StatsdBuilder::from("localhost", 8125)
+    /// .build(Some("prefix"))
+    /// .expect("Could not create StatsdRecorder");
+    /// 
+    /// metrics::set_boxed_recorder(Box::new(recorder));
+    /// metrics::counter!("counter.name",10);
+    /// ```
+    /// will emit a counter metric name as `prefix.counter.name`
     pub fn build(self, prefix: Option<&str>) -> Result<StatsdRecorder, StatsdError> {
         self.is_valid()?;
         // create a local udp socket where the communication needs to happen, the port is set to

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -124,27 +124,8 @@ impl StatsdBuilder {
         self
     }
 
-    /// This method is responsible building the StatsdRecorder and registering it with the metrics
-    /// system. It configures the underlying metrics sink for the [`StatsdClient`] with the values
-    /// provided e.g. `queue_size`, `buffer_size` etc.
-    ///
-    /// All the metrics emitted from the recorder are prefixed with the prefix that's provided here.
-    ///
-    /// # Examples
-    /// ```
-    /// use metrics_exporter_statsd::StatsdBuilder;
-    /// StatsdBuilder::from("localhost", 8125).install(Some("prefix"));
-    /// metrics::counter!("counter.name",10);
-    /// ```
-    /// will emit a counter metric name as `prefix.counter.name`
-    pub fn install(self, prefix: Option<&str>) -> Result<(), StatsdError> {
-        self.is_valid()?;
-        let recorder = self.build(prefix)?;
-        metrics::set_boxed_recorder(Box::new(recorder))?;
-        Ok(())
-    }
-
     pub fn build(self, prefix: Option<&str>) -> Result<StatsdRecorder, StatsdError> {
+        self.is_valid()?;
         // create a local udp socket where the communication needs to happen, the port is set to
         // 0 so that we can pick any available port on the host. We also want this socket to be
         // non-blocking
@@ -286,7 +267,7 @@ mod tests {
     #[should_panic]
     fn bad_host_name() {
         StatsdBuilder::from("", 10)
-            .install(None)
+            .build(None)
             .expect("this should panic");
     }
 
@@ -294,7 +275,7 @@ mod tests {
     #[should_panic]
     fn bad_port() {
         StatsdBuilder::from("127.0.0.1", 0)
-            .install(None)
+            .build(None)
             .expect("this should panic");
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -124,7 +124,7 @@ impl StatsdBuilder {
         self
     }
 
-    /// This method is responsible building the StatsdRecorder. It configures the underlying metrics sink for 
+    /// This method is responsible building the StatsdRecorder. It configures the underlying metrics sink for
     /// the [`StatsdClient`] with the values provided e.g. `queue_size`, `buffer_size` etc.
     ///
     /// All the metrics emitted from the recorder are prefixed with the prefix that's provided here.
@@ -133,9 +133,9 @@ impl StatsdBuilder {
     /// ```
     /// use metrics_exporter_statsd::StatsdBuilder;
     /// let recorder = StatsdBuilder::from("localhost", 8125)
-    /// .build(Some("prefix"))
-    /// .expect("Could not create StatsdRecorder");
-    /// 
+    ///                .build(Some("prefix"))
+    ///                .expect("Could not create StatsdRecorder");
+    ///
     /// metrics::set_boxed_recorder(Box::new(recorder));
     /// metrics::counter!("counter.name",10);
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 //! A [`metrics`] exporter that supports reporting metrics to Statsd. This exporter is basically
 //! a thin wrapper on top of the [`cadence`] crate which supports Statsd/Datadog style metrics.
 //!
+//! **Versions of this crate are tightly coupled to metrics crate versions**
+//! 
 //! # Usage
 //!
 //! ```
@@ -122,8 +124,8 @@
 //! between `metrics-recorder-statsd` and `metrics`, you'll get a build-time error (rather than Cargo silently
 //! linking in two versions of `metrics`, which would result in `metrics` silently dropping all your data).
 //! 
-//! In addition, we align the version of this library with the version of metrics crate it uses. Hopefully that provides a somewhat 
-//! subtle hint to the users about what to expect compatibility wise between the two crates. 
+//! 
+
 
 mod recorder;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! a thin wrapper on top of the [`cadence`] crate which supports Statsd/Datadog style metrics.
 //!
 //! **Versions of this crate are tightly coupled to metrics crate versions**
-//! 
+//!
 //! # Usage
 //!
 //! ```
@@ -13,7 +13,7 @@
 //! .with_buffer_size(1024)
 //! .build(Some("prefix"))
 //! .expect("Could not create StatsdRecorder");
-//! 
+//!
 //! metrics::set_boxed_recorder(Box::new(recorder));
 //! ```
 //!
@@ -103,7 +103,7 @@
 //! .histogram_is_distribution()
 //! .build(Some("prefix"))
 //! .expect("Could not create StatsdRecorder");
-//! 
+//!
 //! metrics::set_boxed_recorder(Box::new(recorder));
 //!```
 //!
@@ -118,15 +118,11 @@
 //!
 //! **Note:** Most of the other metrics-rs builders provide a convenience method for installing a global recorder. E.g
 //! for Prometheus or TCP metrics exporters you could do something along the lines of `PrometheusBuilder::new().install()`.
-//! 
+//!
 //! This library does not have an `.install()` method. Instead, use `.build()` and call
 //! `metrics::set_boxed_recorder`, as in the example code. This ensures that if you ever have a version mismatch
 //! between `metrics-recorder-statsd` and `metrics`, you'll get a build-time error (rather than Cargo silently
 //! linking in two versions of `metrics`, which would result in `metrics` silently dropping all your data).
-//! 
-//! 
-
-
 mod recorder;
 
 pub use self::recorder::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,8 @@
 //! .with_queue_size(5000)
 //! .with_buffer_size(1024)
 //! .histogram_is_distribution()
-//! .build(Some("prefix")).expect("Could not create StatsdRecorder");
+//! .build(Some("prefix"))
+//! .expect("Could not create StatsdRecorder");
 //! 
 //! metrics::set_boxed_recorder(Box::new(recorder));
 //!```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,14 +116,10 @@
 //! **Note:** Most of the other metrics-rs builders provide a convenience method for installing a global recorder. E.g
 //! for Prometheus or TCP metrics exporters you could do something along the lines of `PrometheusBuilder::new().install()`.
 //! 
-//! This library does not provide such convenience method, the reason being that this is a independent exporter library
-//! and the version of `metrics` library that this library depends on might defer from the version you app uses. This 
-//! causes cargo to link both versions of the metrics crate, resulting in recorder installed in `metric-exporter-statsd` and
-//! the calls to `metrics::*` going through the version linked to your app. 
-//! 
-//! Having this library only return a recorder prevents this problem and also surfaces any version mismatch issues from upgrading
-//! one but not the other. 
-//! 
+//! This library does not have an `.install()` method. Instead, use `.build()` and call
+//! `metrics::set_boxed_recorder`, as in the example code. This ensures that if you ever have a version mismatch
+//! between `metrics-recorder-statsd` and `metrics`, you'll get a build-time error (rather than Cargo silently
+//! linking in two versions of `metrics`, which would result in `metrics` silently dropping all your data).
 //! 
 //! In addition, we align the version of this library with the version of metrics crate it uses. Hopefully that provides a somewhat 
 //! subtle hint to the users about what to expect compatibility wise between the two crates. 


### PR DESCRIPTION
- Removed the support for installing global recorder via `StatsdBuilder` and updated the documents/CHANGELOG to reflect what's changing. The version of this crate now changes to 0.18.0 to match the version of `metrics` lib