### PR TITLE
Change docs link to point to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A [metrics-rs](https://github.com/metrics-rs/metrics/) exporter that supports reporting metrics to StatsD. This exporter is basically a thin wrapper on top of the [`cadence`][cadence] crate which supports Statsd/Datadog style metrics.
 
-Check out [crates.io](https://crates.io/crates/metrics-exporter-statsd) documentation for how to use this library. 
+Check out [docs.rs documentation](https://docs.rs/metrics-exporter-statsd) for how to use this library.
 
 ## Contribution
 


### PR DESCRIPTION
The link is currently self-referential: literally in the case of clicking on it while on crates.io, and effectively in the case of clicking on it from the repo, since the crates.io page repeats the readme of the repo.

This changes the link to the docs.rs link that will resolve to the latest published version.