### PR TITLE
Make `HistogramType` public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,3 +131,5 @@ mod builder;
 mod types;
 
 pub use self::builder::*;
+
+pub use types::HistogramType;


### PR DESCRIPTION
This enables direct construction of the `StatsdRecorder` type for cases where a different sink configuration is desired.