### PR TITLE
Bump to metrics 0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,12 +56,11 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "metrics"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+checksum = "77b9e10a211c839210fd7f99954bda26e5f8e26ec686ad68da6a32df7c80e782"
 dependencies = [
  "ahash",
- "metrics-macros",
  "portable-atomic",
 ]
 
@@ -72,17 +71,6 @@ dependencies = [
  "cadence",
  "metrics",
  "thiserror",
-]
-
-[[package]]
-name = "metrics-macros"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ categories = ["observability", "operations"]
 
 [dependencies]
 cadence = "0.29"
-metrics = "0.21"
+metrics = "0.22"
 thiserror = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,19 +14,19 @@
 //! .build(Some("prefix"))
 //! .expect("Could not create StatsdRecorder");
 //!
-//! metrics::set_boxed_recorder(Box::new(recorder));
+//! metrics::set_global_recorder(recorder);
 //! ```
 //!
 //! You can then continue to use [`metrics`] as usual:
 //!
 //! ```
-//! metrics::increment_counter!("counter.name");
+//! metrics::counter!("counter.name").increment(1);
 //! ```
 //!
 //! Labels are translated to datadog style tags:
 //!
 //!```
-//! metrics::gauge!("gauge.name", 100.0 , "tag" => "value");
+//! metrics::gauge!("gauge.name", "tag" => "value").set(100.0);
 //!```
 //! will translate to `gauge.name:50.25|g|#tag:value` and should render appropriately in systems
 //! like Datadog.
@@ -56,7 +56,7 @@
 //! like to override it for a given metric you can still do so:
 //!
 //! ```
-//! metrics::histogram!("metric.name", 100.0, "histogram"=> "histogram","tag"=>"value")
+//! metrics::histogram!("metric.name", "histogram"=> "histogram","tag"=>"value").record(100.0)
 //! ```
 //! This will emit the usual histogram metric this `metric.name:100|h|#tag:value`.
 //!
@@ -73,7 +73,7 @@
 //!
 //! **Reporting distributions:**
 //! ```
-//! metrics::histogram!("metric.name", 100.0, "histogram"=>"distribution", "tag"=>"value")
+//! metrics::histogram!("metric.name", "histogram"=>"distribution", "tag"=>"value").record(100.0)
 //! ```
 //! This will emit a metric like this: `metric.name:100|d|#tag:value`, note the metric type has
 //! changed from `h` to `d`.
@@ -84,7 +84,7 @@
 //!
 //! **Reporting timers:**
 //! ```
-//! metrics::histogram!("metric.name", 100.0, "histogram"=>"timer", "tag"=>"value")
+//! metrics::histogram!("metric.name", "histogram"=>"timer", "tag"=>"value").record(100.0)
 //! ```
 //! This will emit a metric like this: `metric.name:100|ms|#tag:value`, note the metric type has
 //! changed from `h` to `ms`.
@@ -104,14 +104,14 @@
 //! .build(Some("prefix"))
 //! .expect("Could not create StatsdRecorder");
 //!
-//! metrics::set_boxed_recorder(Box::new(recorder));
+//! metrics::set_global_recorder(recorder);
 //!```
 //!
 //! Once the exporter is marked this way then all the histograms will be reported as distributions
 //! by default unless labeled differently. For example following statement:
 //!
 //! ```
-//! metrics::histogram!("metric.name", 100.0, "tag"=>"value")
+//! metrics::histogram!("metric.name", "tag"=>"value").record(100.0)
 //! ```
 //! This will emit a metric like this: `metric.name:100|d|#tag:value`, note the metric type has
 //! emitted here is `d` and not `h`.

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -5,7 +5,7 @@ use cadence::{Counted, Distributed, Gauged, Histogrammed, MetricBuilder, StatsdC
 use metrics::{Counter, CounterFn, SharedString};
 use metrics::{Gauge, GaugeFn};
 use metrics::{Histogram, HistogramFn};
-use metrics::{Key, KeyName, Label, Recorder, Unit};
+use metrics::{Key, KeyName, Label, Metadata, Recorder, Unit};
 
 use crate::types::HistogramType;
 
@@ -42,7 +42,7 @@ impl Recorder for StatsdRecorder {
         unimplemented!("statsd recording does not support descriptions.")
     }
 
-    fn register_counter(&self, key: &Key) -> Counter {
+    fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
         Counter::from_arc(Arc::new(Handle::new(
             key.clone(),
             self.statsd.clone(),
@@ -50,7 +50,7 @@ impl Recorder for StatsdRecorder {
         )))
     }
 
-    fn register_gauge(&self, key: &Key) -> Gauge {
+    fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
         Gauge::from_arc(Arc::new(Handle::new(
             key.clone(),
             self.statsd.clone(),
@@ -58,7 +58,7 @@ impl Recorder for StatsdRecorder {
         )))
     }
 
-    fn register_histogram(&self, key: &Key) -> Histogram {
+    fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
         Histogram::from_arc(Arc::new(Handle::new(
             key.clone(),
             self.statsd.clone(),


### PR DESCRIPTION
https://github.com/metrics-rs/metrics/compare/metrics-v0.21.1...metrics-v0.22.0

There are some breaking changes:

- https://github.com/metrics-rs/metrics/pull/414 Added a generic recorder to `SetRecorderError` and removed `set_boxed_recorder`
- https://github.com/metrics-rs/metrics/pull/380 Added metadata to the metrics
- https://github.com/metrics-rs/metrics/pull/394 Reworked the macros

This makes the necessary adjustments and replaces https://github.com/github/metrics-exporter-statsd/pull/40.