### PR TITLE
Cadence counter update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ keywords = ["metrics", "statsd"]
 categories = ["observability", "operations"]
 
 [dependencies]
-cadence = "1.0"
+cadence = "1.3"
 metrics = "0.22"
 thiserror = "1.0"

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -87,8 +87,7 @@ impl Handle {
 
 impl CounterFn for Handle {
     fn increment(&self, value: u64) {
-        // this is an unfortunate conversion, probably deserves an issue on cadence?
-        let mb = self.statsd.count_with_tags(self.key.name(), value as i64);
+        let mb = self.statsd.count_with_tags(self.key.name());
         Self::apply_tags(self.key.labels().collect(), mb).send();
     }
 


### PR DESCRIPTION
Cadence v1.3.0 has support for u64 counters, so I removed the conversion and updated the cadence version in Cargo.toml