### PR TITLE
Bump to metrics 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "metrics"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
+checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
 dependencies = [
  "ahash",
  "portable-atomic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ categories = ["observability", "operations"]
 
 [dependencies]
 cadence = "1.3"
-metrics = "0.22"
+metrics = "0.23"
 thiserror = "1.0"


### PR DESCRIPTION
https://github.com/metrics-rs/metrics/compare/metrics-v0.22.0...metrics-v0.23.0

The breaking change is an MSRVV bump to 1.70.0 (from 1.65.0)