### PR TITLE
feat: bump cadence from 1.4.0 to 1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ dependencies = [
 
 [[package]]
 name = "cadence"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f338b979d9ebfff4bb9801ae8f3af0dc3615f7f1ca963f2e4782bcf9acb3753"
+checksum = "62fd689c825a93386a2ac05a46f88342c6df9ec3e79416f665650614e92e7475"
 dependencies = [
  "crossbeam-channel",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ categories = ["observability", "operations"]
 
 [dependencies]
 metrics = "0.23"
-cadence = "1.4"
+cadence = "1.5.0"
 thiserror = "1.0"


### PR DESCRIPTION
Hey guys! @mbellani 

I am using the new way cadence provides to us in the new library version, and I'm using this library to export metrics to datadog in the statsd style. To make this possible, it is necessary to create a new version of this lib.