### PR TITLE
Updated category slugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/github/metrics-exporter-statsd"
 homepage = "https://github.com/github/metrics-exporter-statsd"
 keywords = ["metrics", "statsd"]
-categories = ["observability", "operations"]
+categories = ["development-tools"]
 
 [dependencies]
 metrics = "0.24"


### PR DESCRIPTION
Observability and operations slugs are no longer supported. Updating it to pick the best match from https://crates.io/category_slugs.