### PR TITLE
remove the unused Histogram struct

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1,15 +1,4 @@
-use cadence::Metric;
 use metrics::{Key, Label};
-
-pub struct Histogram {
-    repr: String,
-}
-
-impl Metric for Histogram {
-    fn as_metric_str(&self) -> &str {
-        self.repr.as_str()
-    }
-}
 
 /// This enum represents all the different histogram transformations that we support. Each histogram
 /// value also takes tags which should be remaining tags after stripping of the `histogram` label.


### PR DESCRIPTION
CI on https://github.com/github/metrics-exporter-statsd/pull/99 is failing because (I think) the newest version of Rust is now warning about unused public items (the `Histogram` struct in this case) when you run tests, and we escalate those warnings to failures in CI.

I looked, and it really doesn't look like the `Histogram` struct is used by anything, and there's a pretty decent set of tests. My only uncertainty is that maybe the struct is only used by consumers for some reason I don't understand?

cc @mbellani am I doing the right thing here?

Unblocks #99 